### PR TITLE
Fix report cannot open in online task

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1319,7 +1319,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self.current_analysis_task = analysis_task
 
             progress_dialog.analysis_task = analysis_task
-            progress_dialog.scenario_id = str(scenario.uuid)
 
             report_running = partial(self.on_report_running, progress_dialog)
             report_error = partial(self.on_report_error, progress_dialog)
@@ -1375,6 +1374,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         :type report_manager: ReportManager
         """
 
+        progress_dialog.scenario_id = str(task.scenario.uuid)
         self.scenario_result = task.scenario_result
         self.scenario_results(task, report_manager, progress_dialog)
 


### PR DESCRIPTION
This is PR for https://github.com/ConservationInternational/cplus-plugin/issues/457

When creating `ScenarioAnalysisTask`, `scenario_id` is set to None.
Then, on the nex few lines, the `scenario_id` in `progress_dialog` is set to match the scenario_id.

This causes `progress_dialog`'s `scenario_id` to be None. Causing it not detecting the report result once generated.

What I did in this PR, is setting `progress_dialog`'s `scenario_id` once the analysis is completed.

I've tested for both online and local processing, they both could now show PDF and Layout Manager.